### PR TITLE
[API] mypage/modifyuseredit

### DIFF
--- a/controllers/mypage/useredit.js
+++ b/controllers/mypage/useredit.js
@@ -6,12 +6,6 @@ module.exports = async (req, res) => {
     const body = req.body
     body.createdAt = new Date()
 
-    Object.keys(body).map(el => {
-        if (!body.el) {
-            delete body.el
-        }
-    })
-
     const authorization = req.headers.authorization
 
     if (authorization === undefined) {


### PR DESCRIPTION
mypage/modifyuseredit

mypage/useredit 수정
body에 담기는값을 해당 userid의 데이터베이스에서 반영
req.body에 null 필터링 제거
(클라이언트에서 req.body에 null이 아닌 값을 전송해주지 않는다)

resolves #46 